### PR TITLE
accept react and react-dom v15 as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "homepage": "https://github.com/ogaya/react-gridview",
   "peerDependencies": {
     "immutable": "^3.7.6",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.6",


### PR DESCRIPTION
Hi, just a little request to avoid peer dependencies errors when installing react-gridview in a react v15 project.
